### PR TITLE
Add Arbiscan MCP tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the Arbitrum Vibekit will be documented in this file.
 │ ✨ ADDED                                             │
 │ • Compound Finance Model Context Protocol (MCP)      │
 │   - Supply, borrow, repay, getMarketData
+│ • Arbiscan MCP tool                                   │
+│   - Additional API endpoints                          │
 └──────────────────────────────────────────────────────┘
 ┌──────────────────────────────────────────────────────┐
 │ VERSION 0.0.2                             2025-04-28 │

--- a/typescript/lib/mcp-tools/arbscan-mcp/.env.example
+++ b/typescript/lib/mcp-tools/arbscan-mcp/.env.example
@@ -1,0 +1,4 @@
+# Arbiscan MCP Server configuration
+ARBISCAN_API_KEY=
+ARBISCAN_BASE_URL=https://api.arbiscan.io/api
+ARBISCAN_TESTNET_BASE_URL=https://api-testnet.arbiscan.io/api

--- a/typescript/lib/mcp-tools/arbscan-mcp/README.md
+++ b/typescript/lib/mcp-tools/arbscan-mcp/README.md
@@ -1,0 +1,41 @@
+# Arbiscan MCP Server
+
+This package exposes a simple Model Context Protocol (MCP) server that wraps the [Arbiscan](https://arbiscan.io/) API. It allows Vibekit agents to query on-chain data from Arbitrum One (mainnet) and Arbitrum Sepolia (testnet).
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and provide your Arbiscan API key:
+
+```
+cp .env.example .env
+```
+
+- `ARBISCAN_API_KEY` – Your Arbiscan API key.
+- `ARBISCAN_BASE_URL` – (optional) Base URL for mainnet. Defaults to `https://api.arbiscan.io/api`.
+- `ARBISCAN_TESTNET_BASE_URL` – (optional) Base URL for testnet. Defaults to `https://api-testnet.arbiscan.io/api`.
+
+## Usage
+
+Install dependencies and run the server in development mode:
+
+```
+pnpm install
+pnpm start
+```
+
+You can inspect the MCP API with:
+
+```
+pnpm run build && npx -y @modelcontextprotocol/inspector node ./dist/index.js
+```
+
+## Tools Exposed
+
+- `getAccountBalance` – Retrieve ETH balance for an address.
+- `getTransaction` – Fetch details for a transaction hash.
+- `getTokenTransfers` – List ERC‑20 token transfers involving an address.
+- `getTokenBalance` – Get an ERC‑20 token balance for a wallet.
+- `getBlockNumber` – Return the latest block number.
+- `getGasPrice` – Return the current gas price in wei.
+
+Each tool accepts a `network` parameter of `mainnet` or `testnet` to choose the Arbitrum chain.

--- a/typescript/lib/mcp-tools/arbscan-mcp/package.json
+++ b/typescript/lib/mcp-tools/arbscan-mcp/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "arbscan-mcp-tool-server",
+  "version": "1.1.0",
+  "description": "MCP stdio server exposing Arbiscan API endpoints",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "arbscan-mcp": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc && node -e \"const { join } = require('path'); const fs=require('fs'); const p=join(process.cwd(),'dist/index.js'); if(fs.existsSync(p)){ fs.chmodSync(p,'755'); }\"",
+    "start": "tsx src/index.ts",
+    "dev": "tsx watch src/index.ts",
+    "inspect:npx": "pnpm run build && npx -y @modelcontextprotocol/inspector node ./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "mcp",
+    "arbiscan",
+    "arbitrum",
+    "blockchain"
+  ],
+  "license": "ISC",
+  "packageManager": "pnpm@10.7.0",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.14",
+    "dotenv": "^16.3.1",
+    "tsx": "^4.19.3",
+    "typescript": "^5.8.2"
+  }
+}

--- a/typescript/lib/mcp-tools/arbscan-mcp/src/index.ts
+++ b/typescript/lib/mcp-tools/arbscan-mcp/src/index.ts
@@ -1,0 +1,230 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import 'dotenv/config';
+
+const DEFAULT_MAINNET_URL = 'https://api.arbiscan.io/api';
+const DEFAULT_TESTNET_URL = 'https://api-testnet.arbiscan.io/api';
+
+function getBaseUrl(network: string) {
+  if (network === 'testnet') {
+    return process.env.ARBISCAN_TESTNET_BASE_URL || DEFAULT_TESTNET_URL;
+  }
+  return process.env.ARBISCAN_BASE_URL || DEFAULT_MAINNET_URL;
+}
+
+async function callArbiscan(params: Record<string, string>, network: string) {
+  const url = new URL(getBaseUrl(network));
+  Object.entries(params).forEach(([k, v]) => url.searchParams.append(k, v));
+  url.searchParams.append('apikey', process.env.ARBISCAN_API_KEY || '');
+
+  const res = await fetch(url.toString());
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  return (await res.json()) as unknown;
+}
+
+const networkEnum = z.enum(['mainnet', 'testnet']);
+
+const getAccountBalanceSchema = {
+  address: z.string().describe('The account address to query.'),
+  network: networkEnum.default('mainnet').describe('Arbitrum network.'),
+  tag: z.string().default('latest').describe('Block tag for balance query.'),
+};
+
+type GetAccountBalanceParams = z.infer<ReturnType<typeof z.object<typeof getAccountBalanceSchema>>>;
+
+const getTransactionSchema = {
+  hash: z.string().describe('Transaction hash to fetch.'),
+  network: networkEnum.default('mainnet').describe('Arbitrum network.'),
+};
+
+type GetTransactionParams = z.infer<ReturnType<typeof z.object<typeof getTransactionSchema>>>;
+
+const getTokenTransfersSchema = {
+  address: z.string().describe('Account address to fetch transfers for.'),
+  network: networkEnum.default('mainnet').describe('Arbitrum network.'),
+  page: z.string().optional().describe('Page number for pagination.'),
+  offset: z.string().optional().describe('Number of results per page.'),
+};
+
+type GetTokenTransfersParams = z.infer<ReturnType<typeof z.object<typeof getTokenTransfersSchema>>>;
+
+const getTokenBalanceSchema = {
+  address: z.string().describe('Wallet address holding the token.'),
+  contract: z.string().describe('ERC-20 token contract address.'),
+  network: networkEnum.default('mainnet').describe('Arbitrum network.'),
+  tag: z.string().default('latest').describe('Block tag for balance query.'),
+};
+
+type GetTokenBalanceParams = z.infer<ReturnType<typeof z.object<typeof getTokenBalanceSchema>>>;
+
+const getBlockNumberSchema = {
+  network: networkEnum.default('mainnet').describe('Arbitrum network.'),
+};
+
+type GetBlockNumberParams = z.infer<ReturnType<typeof z.object<typeof getBlockNumberSchema>>>;
+
+const getGasPriceSchema = {
+  network: networkEnum.default('mainnet').describe('Arbitrum network.'),
+};
+
+type GetGasPriceParams = z.infer<ReturnType<typeof z.object<typeof getGasPriceSchema>>>;
+
+const server = new McpServer({ name: 'arbscan-mcp-tool-server', version: '1.0.0' });
+
+server.tool(
+  'getAccountBalance',
+  'Get ETH balance for an address on Arbitrum.',
+  getAccountBalanceSchema,
+  async (params: GetAccountBalanceParams) => {
+    try {
+      const data = await callArbiscan(
+        {
+          module: 'account',
+          action: 'balance',
+          address: params.address,
+          tag: params.tag,
+        },
+        params.network,
+      );
+      return { content: [{ type: 'text', text: JSON.stringify(data) }] };
+    } catch (error) {
+      return { isError: true, content: [{ type: 'text', text: `Error: ${(error as Error).message}` }] };
+    }
+  },
+);
+
+server.tool(
+  'getTransaction',
+  'Get transaction details by hash.',
+  getTransactionSchema,
+  async (params: GetTransactionParams) => {
+    try {
+      const data = await callArbiscan(
+        {
+          module: 'proxy',
+          action: 'eth_getTransactionByHash',
+          txhash: params.hash,
+        },
+        params.network,
+      );
+      return { content: [{ type: 'text', text: JSON.stringify(data) }] };
+    } catch (error) {
+      return { isError: true, content: [{ type: 'text', text: `Error: ${(error as Error).message}` }] };
+    }
+  },
+);
+
+server.tool(
+  'getTokenTransfers',
+  'List ERC-20 token transfers for an address.',
+  getTokenTransfersSchema,
+  async (params: GetTokenTransfersParams) => {
+    try {
+      const data = await callArbiscan(
+        {
+          module: 'account',
+          action: 'tokentx',
+          address: params.address,
+          page: params.page || '1',
+          offset: params.offset || '100',
+          sort: 'asc',
+        },
+        params.network,
+      );
+      return { content: [{ type: 'text', text: JSON.stringify(data) }] };
+    } catch (error) {
+      return { isError: true, content: [{ type: 'text', text: `Error: ${(error as Error).message}` }] };
+    }
+  },
+);
+
+server.tool(
+  'getTokenBalance',
+  'Get the ERC-20 token balance for an address.',
+  getTokenBalanceSchema,
+  async (params: GetTokenBalanceParams) => {
+    try {
+      const data = await callArbiscan(
+        {
+          module: 'account',
+          action: 'tokenbalance',
+          contractaddress: params.contract,
+          address: params.address,
+          tag: params.tag,
+        },
+        params.network,
+      );
+      return { content: [{ type: 'text', text: JSON.stringify(data) }] };
+    } catch (error) {
+      return { isError: true, content: [{ type: 'text', text: `Error: ${(error as Error).message}` }] };
+    }
+  },
+);
+
+server.tool(
+  'getBlockNumber',
+  'Get the latest block number.',
+  getBlockNumberSchema,
+  async (params: GetBlockNumberParams) => {
+    try {
+      const data = await callArbiscan(
+        {
+          module: 'proxy',
+          action: 'eth_blockNumber',
+        },
+        params.network,
+      );
+      return { content: [{ type: 'text', text: JSON.stringify(data) }] };
+    } catch (error) {
+      return { isError: true, content: [{ type: 'text', text: `Error: ${(error as Error).message}` }] };
+    }
+  },
+);
+
+server.tool(
+  'getGasPrice',
+  'Get the current gas price in wei.',
+  getGasPriceSchema,
+  async (params: GetGasPriceParams) => {
+    try {
+      const data = await callArbiscan(
+        {
+          module: 'proxy',
+          action: 'eth_gasPrice',
+        },
+        params.network,
+      );
+      return { content: [{ type: 'text', text: JSON.stringify(data) }] };
+    } catch (error) {
+      return { isError: true, content: [{ type: 'text', text: `Error: ${(error as Error).message}` }] };
+    }
+  },
+);
+
+async function main() {
+  const transport = new StdioServerTransport();
+  try {
+    await server.connect(transport);
+    console.error('Arbiscan MCP server started.');
+    const cleanup = async () => {
+      try {
+        await server.close();
+        console.error('Server closed.');
+        process.exit(0);
+      } catch (err) {
+        console.error('Error during shutdown:', err);
+        process.exit(1);
+      }
+    };
+    process.on('SIGINT', cleanup);
+    process.on('SIGTERM', cleanup);
+  } catch (err) {
+    console.error('Failed to start server:', err);
+    process.exit(1);
+  }
+}
+
+main();

--- a/typescript/lib/mcp-tools/arbscan-mcp/tsconfig.json
+++ b/typescript/lib/mcp-tools/arbscan-mcp/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add `arbscan-mcp` MCP tool package
- support mainnet and testnet URLs via env vars
- document environment variables and usage
- support more API endpoints
- update CHANGELOG

## Testing
- `pnpm -r --filter arbscan-mcp-tool-server run build`
- `pnpm test` *(fails: ENETUNREACH for xAI API)*

------
https://chatgpt.com/codex/tasks/task_e_684ecd09c15c83279714131ec3d953d2